### PR TITLE
Fix dialyzer errors

### DIFF
--- a/include/canister.hrl
+++ b/include/canister.hrl
@@ -5,7 +5,7 @@
 
 -record(canister_times, {
     id,
-    last_access=os:timestamp()  :: erlang:timestamp(),
-    last_update=os:timestamp()  :: erlang:timestamp(),
+    last_access=os:timestamp()  ::  undefined | erlang:timestamp(),
+    last_update=os:timestamp()  ::  undefined | erlang:timestamp(),
     deleted=undefined           :: undefined | erlang:timestamp()
 }).

--- a/src/canister.erl
+++ b/src/canister.erl
@@ -233,8 +233,8 @@ touch_local(ID) ->
 touch_local(ID, Time) ->
     update_access_time(ID, Time).
 
-queue_delete(ID, Time) ->
-    canister_sync:send_delete(ID, Time).
+queue_delete(ID, _Time) ->
+    canister_sync:send_delete(ID).
 
 record_status(ID) ->
     case deleted_time(ID) of
@@ -330,7 +330,9 @@ clear_untouched_sessions() ->
     SessionsToSync = lists:filtermap(fun(Sess) ->
         case clear_untouched_session(Sess) of
             ok -> false;
-            {resync, _Node} -> {true, Sess#canister_times.id}
+            {resync, _Node} ->
+                {ID, _LastAccess} = Sess,
+                {true, ID}
         end
     end, Sessions),
     lists:foreach(fun(ID) ->
@@ -372,7 +374,7 @@ latest_cluster_time(Type, ID, LastAccess) ->
             case compare_latest_node_time(Nodes, Type, ID, LastAccess) of
                 ok ->
                     ok;
-                {Node, NewLastAccess} ->
+                {ok, Node, NewLastAccess} ->
                     {ok, NewLastAccess, Node}
             end
     end.

--- a/src/canister_config.erl
+++ b/src/canister_config.erl
@@ -30,12 +30,8 @@ summarize() ->
     Msgs = [format_config(Field) || Field <- Fields],
     Nodes = default_cluster(),
     ClusterMsg = format_cluster(Nodes),
-    Msg = [
-        "Nitrogen Canister Session Manager Configuration:\n",
-        ClusterMsg,
-        Msgs
-    ],
-    io:format(Msg).
+    MsgHeader = "Nitrogen Canister Session Manager Configuration:\n~s~s",
+    io:format(MsgHeader, [ClusterMsg, Msgs]).
 
 format_cluster([]) ->
     "*** Canister: No auto-connected cluster nodes (default_cluster) configured. You'll have to manually connect nodes (net_kernel:connect_node(Node))\n";

--- a/src/canister_sync.erl
+++ b/src/canister_sync.erl
@@ -8,6 +8,7 @@
     send_update/2,
     send_update/3,
     send_clear/2,
+    send_delete/1,
     send_touch/2,
     get_nodes/0,
     get_node_to_resync/0
@@ -51,6 +52,9 @@ send_clear(ID, Time) ->
 
 send_touch(ID, Time) ->
     gen_server:cast(?SERVER, {cast, {touch, ID, Time}}).
+
+send_delete(ID) ->
+    gen_server:cast(?SERVER, {cast, {delete, ID}}).
 
 init([]) ->
     ok = init_ets(),
@@ -176,6 +180,9 @@ handle_remote({touch, ID, Time}) ->
     ok;
 handle_remote({clear, ID, Time}) ->
     canister:clear(ID, Time),
+    ok;
+handle_remote({delete, ID}) ->
+    canister:delete(ID),
     ok.
 
 assemble_and_requeue(Nodes) ->
@@ -199,8 +206,6 @@ assemble_and_requeue(Nodes) ->
 get_node_to_resync() ->
     get_node_to_resync([node() | get_nodes()]).
 
-get_node_to_resync([]) ->
-    undefined;
 get_node_to_resync(Nodes) ->
     case which_nodes_are_resyncing(Nodes) of
         [] -> hd(Nodes);


### PR DESCRIPTION
   ==> Checking 240 files in _build/default/rebar3_24.3.4.16_plt...
   ===> Doing success typing analysis...
   ===> Resolving project warning files...
   ===> Analyzing 8 files with _build/default/rebar3_24.3.4.16_plt...

   src/canister.erl
   Line 63 Column 1: Function start/0 has no local return
   Line 237 Column 5: Call to missing or unexported function
   canister_sync:send_delete/2
   Line 266 Column 1: Function update_delete_time/1 has no local return
   Line 269 Column 1: Function update_delete_time/2 has no local return
   Line 272 Column 21: Record construction
   #canister_times{last_access::'undefined',last_update::'undefined'}
   violates the declared type of field
   last_access::{non_neg_integer(),non_neg_integer(),non_neg_integer()} and
   last_update::{non_neg_integer(),non_neg_integer(),non_neg_integer()}
   Line 333 Column 13: The pattern {'resync', _Node} can never match the
   type 'ok'
   Line 346 Column 9: The pattern {'ok', _, Node} can never match the type
   'ok'
   Line 375 Column 17: The pattern {Node, NewLastAccess} can never match
   the type {'ok',_,_}

   src/canister_app.erl
   Line 12 Column 1: Function start/2 has no local return

   src/canister_config.erl
   Line 20 Column 1: Function summarize/0 has no local return
   Line 38 Column 15: The call io:format(Msg::[[[any()] | char()],...])
   breaks the contract (Format) -> 'ok' when Format :: format()

   src/canister_sup.erl
   Line 16 Column 1: Function start_link/0 has no local return

   src/canister_sync.erl
   Line 202 Column 1: The pattern [] can never match the type
   nonempty_maybe_improper_list()
   ===> Warnings written to _build/default/24.3.4.16.dialyzer_warnings
   ===> Warnings occurred running dialyzer: 13